### PR TITLE
add code to output results under Ubuntu 22.04 LTS

### DIFF
--- a/main.c
+++ b/main.c
@@ -63,8 +63,10 @@ struct KaNode *builtin_tree(struct KaNode *node, struct KaNode **env) {
 }
 
 int main(int argc, char **argv) {
+  
   struct KaNode *env = ka_init();
   struct KaNode *pos = malloc(KANODE_SIZE);
+  struct KaNode *result = malloc(KANODE_SIZE);
 
   ka_def(ka_link(ka_idf("puts"), ka_fn(builtin_puts), 0), &env);
   ka_def(ka_link(ka_idf("tree"), ka_fn(builtin_tree), 0), &env);
@@ -78,7 +80,10 @@ int main(int argc, char **argv) {
       if (input[0] == '\n') continue;
       else if (strcmp(input, "exit\n") == 0) break;
       pos = malloc(KANODE_SIZE);
-      ka_eval(ka_parser(input, &pos), &env);
+
+      result = ka_eval(ka_parser(input, &pos), &env); /* save the result  so we can output it */
+      builtin_puts(result,&env);
+
       input[0] = '\0';
     }
   } else if (argc == 2) {


### PR DESCRIPTION
When I compiled Kamby under Ubuntu 22.04 LTS, there was no output when I entered  1 + 2, nor anything else I tried. This simple hack got me going.